### PR TITLE
Update kksymbols-doc.tex (fix a typo)

### DIFF
--- a/kksymbols-doc.tex
+++ b/kksymbols-doc.tex
@@ -455,7 +455,7 @@ You can also change the current font:
 \end{OutPut}
 
 \subsection{Rotation}
-This package provides \verb|\Rottate| and \verb|\RotYoko|.
+This package provides \verb|\RotTate| and \verb|\RotYoko|.
 
 \begin{description}
   \item[In horizontal mode] The default value is \verb|0|. 


### PR DESCRIPTION
Rottate -> RotTate

(I see in the diff also a change in the line 2288 `\end{document}` but I don't know why, because I have not changed anything on this line. Perhaps because I use a browser with UTF-8 encoding, but mainly with latin characters??? Check if your .tex file will compile with my change, otherwise made the change manually on your side).